### PR TITLE
Fix bug on calendar triple click

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1123,8 +1123,8 @@
             $(window).on('resize.daterangepicker', $.proxy(function(e) { this.move(e); }, this));
 
             this.oldStartDate = this.startDate.clone();
-            this.oldEndDate = this.endDate.clone();
-            this.previousRightTime = this.endDate.clone();
+            this.oldEndDate = this.endDate ? this.endDate.clone() : this.startDate.clone();
+            this.previousRightTime = this.endDate ? this.endDate.clone() : this.startDate.clone();
 
             this.updateView();
             this.container.show();


### PR DESCRIPTION
## Summary

- If the single calendar is set to roundtrip, and the user triple click a date, an error is thrown and the single calendar form breaks. This was caused by essentially creating a new starting date with the 3rd click, and the user never enters the return date before the calendar closes which causes a null pointer error.
- Now if the user triple clicks and closes the calendar and then opens the calendar again, they will be presented with the ability to select their second date, and the calendar no longer breaks.